### PR TITLE
Rendering optimizations

### DIFF
--- a/Col/Col.cs
+++ b/Col/Col.cs
@@ -59,7 +59,7 @@ namespace LakiTool.Col
         public void special_object(short X, short Y, short Z)
         {
             GL.End();
-            GL.Begin(BeginMode.Triangles);
+            GL.Begin(PrimitiveType.Triangles);
         }
     }
 }

--- a/Forms/Form1.Designer.cs
+++ b/Forms/Form1.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.glcontrol1 = new OpenTK.GLControl();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.levelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openLevelFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -53,28 +52,13 @@
             this.label2 = new System.Windows.Forms.Label();
             this.radioButton1 = new System.Windows.Forms.RadioButton();
             this.radioButton2 = new System.Windows.Forms.RadioButton();
+            this.lakiToolGLControl1 = new LakiTool.Forms.LakiToolGLControl();
             this.menuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBar1)).BeginInit();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.tabPage2.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // glcontrol1
-            // 
-            this.glcontrol1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.glcontrol1.BackColor = System.Drawing.Color.Black;
-            this.glcontrol1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.glcontrol1.Location = new System.Drawing.Point(206, 27);
-            this.glcontrol1.Name = "glcontrol1";
-            this.glcontrol1.Size = new System.Drawing.Size(432, 324);
-            this.glcontrol1.TabIndex = 7;
-            this.glcontrol1.VSync = true;
-            this.glcontrol1.Load += new System.EventHandler(this.glcontrol1_Load);
-            this.glcontrol1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.regmousedown);
-            this.glcontrol1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.remouseup);
             // 
             // menuStrip1
             // 
@@ -310,6 +294,23 @@
             this.radioButton2.Text = "Display List(s)";
             this.radioButton2.UseVisualStyleBackColor = true;
             // 
+            // lakiToolGLControl1
+            // 
+            this.lakiToolGLControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lakiToolGLControl1.BackColor = System.Drawing.Color.Black;
+            this.lakiToolGLControl1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.lakiToolGLControl1.Location = new System.Drawing.Point(206, 27);
+            this.lakiToolGLControl1.Name = "lakiToolGLControl1";
+            this.lakiToolGLControl1.Size = new System.Drawing.Size(432, 324);
+            this.lakiToolGLControl1.TabIndex = 21;
+            this.lakiToolGLControl1.VSync = false;
+            this.lakiToolGLControl1.Load += new System.EventHandler(this.LakiToolGLControl1_Load);
+            this.lakiToolGLControl1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LakiToolGLControl1_MouseDown);
+            this.lakiToolGLControl1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.LakiToolGLControl1_MouseUp);
+            this.lakiToolGLControl1.Resize += new System.EventHandler(this.LakiToolGLControl1_Resize);
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -322,8 +323,8 @@
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.trackBar1);
-            this.Controls.Add(this.glcontrol1);
             this.Controls.Add(this.menuStrip1);
+            this.Controls.Add(this.lakiToolGLControl1);
             this.MainMenuStrip = this.menuStrip1;
             this.MinimumSize = new System.Drawing.Size(666, 445);
             this.Name = "Form1";
@@ -345,8 +346,6 @@
         }
 
         #endregion
-
-        private OpenTK.GLControl glcontrol1;
         private System.Windows.Forms.MenuStrip menuStrip1;
         private System.Windows.Forms.ToolStripMenuItem levelToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openLevelFolderToolStripMenuItem;
@@ -371,5 +370,6 @@
         private System.Windows.Forms.ComboBox comboBox2;
         private System.Windows.Forms.Button button5;
         private System.Windows.Forms.ToolStripMenuItem openLevelScriptToolStripMenuItem;
+        private Forms.LakiToolGLControl lakiToolGLControl1;
     }
 }

--- a/Forms/Form1.Designer.cs
+++ b/Forms/Form1.Designer.cs
@@ -305,7 +305,7 @@
             this.lakiToolGLControl1.Name = "lakiToolGLControl1";
             this.lakiToolGLControl1.Size = new System.Drawing.Size(432, 324);
             this.lakiToolGLControl1.TabIndex = 21;
-            this.lakiToolGLControl1.VSync = false;
+            this.lakiToolGLControl1.VSync = true;
             this.lakiToolGLControl1.Load += new System.EventHandler(this.LakiToolGLControl1_Load);
             this.lakiToolGLControl1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LakiToolGLControl1_MouseDown);
             this.lakiToolGLControl1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.LakiToolGLControl1_MouseUp);

--- a/Forms/Form1.cs
+++ b/Forms/Form1.cs
@@ -277,7 +277,7 @@ namespace LakiTool
         {
             Rectangle renderRect = lakiToolGLControl1.ClientRectangle;
             GL.Viewport(renderRect.X, renderRect.Y, renderRect.Width, renderRect.Height);
-            Matrix4 projection = Matrix4.CreatePerspectiveFieldOfView(1.0f, renderRect.Width / (float)renderRect.Height, 1f, 1000.0f);
+            Matrix4 projection = Matrix4.CreatePerspectiveFieldOfView(1.0f, renderRect.Width / (float)renderRect.Height, 1f, 2500.0f);
             GL.MatrixMode(MatrixMode.Projection);
             GL.LoadMatrix(ref projection);
         }

--- a/Forms/Form1.cs
+++ b/Forms/Form1.cs
@@ -19,6 +19,7 @@ namespace LakiTool
         private void LakiToolGLControl1_Load(object sender, EventArgs e)
         {
             InitialiseView();
+            ResetCamera();
         }
 
         private void LakiToolGLControl1_Resize(object sender, EventArgs e)

--- a/Forms/Form1.cs
+++ b/Forms/Form1.cs
@@ -1,20 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using OpenTK;
-using OpenTK.Graphics;
+﻿using OpenTK;
 using OpenTK.Graphics.OpenGL;
-using System.Drawing;
-using System.Drawing.Imaging;
 using OpenTK.Input;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
+using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
-using LakiTool;
-using System.Diagnostics;
 
 namespace LakiTool
 {
@@ -25,76 +16,14 @@ namespace LakiTool
             InitializeComponent();
         }
 
-        static Camera cam = new Camera();
-
-
-        private void glcontrol1_Load(object sender, EventArgs e)
+        private void LakiToolGLControl1_Load(object sender, EventArgs e)
         {
-            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
-            Matrix4 modelview = Matrix4.LookAt(Vector3.Zero, Vector3.UnitZ, Vector3.UnitY);
-            GL.MatrixMode(MatrixMode.Modelview);
-            GL.LoadMatrix(ref modelview);
-            GL.ClearColor(Color.Black);
-            GL.Enable(EnableCap.DepthTest);
-            GL.Enable(EnableCap.Texture2D);
-        }
-
-        private void doRenderStuff(float deltaTime)
-        {
-            checkkeys(deltaTime);
-            checkmouse();
-
-            Render(glcontrol1);
-
-            ProcessTimer();
-        }
-
-        public void Render(GLControl RenderPanel)
-        {
-            Rectangle renderRect = RenderPanel.ClientRectangle;
-
-            GL.Viewport(renderRect.X, renderRect.Y, renderRect.Width, renderRect.Height);
-            Matrix4 projection = cam.GetViewMatrix() * Matrix4.CreatePerspectiveFieldOfView(1.0f, renderRect.Width / (float)renderRect.Height, 1f, 1000.0f);
-            GL.MatrixMode(MatrixMode.Projection);
-            GL.LoadMatrix(ref projection);
             InitialiseView();
-            GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Fill);
-            GL.Enable(EnableCap.DepthTest);
-            GL.Enable(EnableCap.Blend);
-            GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
-            GL.Enable(EnableCap.ColorMaterial);
-            GL.Enable(EnableCap.Normalize);
-            GL.ShadeModel(ShadingModel.Smooth);
-            GL.Enable(EnableCap.Lighting);
-            GL.Enable(EnableCap.Light0);
-            GL.Enable(EnableCap.Texture2D);
-            Vector3 lookat = new Vector3();
-            lookat.X = (float)(Math.Cos((float)cam.Orientation.X) * Math.Cos((float)cam.Orientation.Y));
-            lookat.Y = (float)Math.Sin((float)cam.Orientation.Y);
-            lookat.Z = (float)(Math.Sin((float)cam.Orientation.X) * Math.Cos((float)cam.Orientation.Y));
-            GL.Light(LightName.Light0, LightParameter.Position, new float[] { Math.Abs(lookat.X), Math.Abs(lookat.Y), Math.Abs(lookat.Z), 0.0f });
-
-            renderer.Render();
-
-            RenderPanel.SwapBuffers();
         }
 
-        LakiTool.Render.Renderer renderer = new LakiTool.Render.Renderer();
-
-        public static void InitialiseView()
+        private void LakiToolGLControl1_Resize(object sender, EventArgs e)
         {
-            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
-            Matrix4 modelview = Matrix4.LookAt(Vector3.Zero, Vector3.UnitZ, Vector3.UnitY);
-            GL.MatrixMode(MatrixMode.Modelview);
-            GL.LoadMatrix(ref modelview);
-            GL.ClearColor(Color.LightBlue);
-            GL.CullFace(CullFaceMode.Back);
-            GL.Enable(EnableCap.Blend);
-            GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
-            GL.Enable(EnableCap.DepthTest);
-            GL.DepthFunc(DepthFunction.Lequal);
-            GL.Enable(EnableCap.AlphaTest);
-            GL.AlphaFunc(AlphaFunction.Gequal, 0.05f);
+            UpdateProjectionMatrix();
         }
 
         private void openLevelFolderToolStripMenuItem_Click(object sender, EventArgs e)
@@ -116,7 +45,7 @@ namespace LakiTool
 
         private void button3_Click(object sender, EventArgs e)
         {
-            cam.Position = Vector3.Zero;
+            ResetCamera();
         }
 
         private void openGeoScriptToolStripMenuItem_Click(object sender, EventArgs e)
@@ -218,13 +147,13 @@ namespace LakiTool
             MouseState mstate = Mouse.GetState();
 
             Vector2 CurrentMousePosition = new Vector2(mstate.X, mstate.Y);
-            
+
             if (mstate.IsButtonDown(MouseButton.Left) && mic)
             {
                 Vector2 delta = CurrentMousePosition - PreviousMousePosition;
                 cam.AddRotation(-delta.X, -delta.Y);
 
-                Rectangle glControlScreenRect = glcontrol1.RectangleToScreen(glcontrol1.ClientRectangle);
+                Rectangle glControlScreenRect = lakiToolGLControl1.RectangleToScreen(lakiToolGLControl1.ClientRectangle);
                 if (Cursor.Position.X < glControlScreenRect.Left) Cursor.Position = new Point(glControlScreenRect.Right, Cursor.Position.Y);
                 else if (Cursor.Position.X > glControlScreenRect.Right) Cursor.Position = new Point(glControlScreenRect.Left, Cursor.Position.Y);
                 if (Cursor.Position.Y < glControlScreenRect.Top) Cursor.Position = new Point(Cursor.Position.X, glControlScreenRect.Bottom);
@@ -234,12 +163,12 @@ namespace LakiTool
             PreviousMousePosition = CurrentMousePosition;
         }
 
-        private void regmousedown(object sender, System.Windows.Forms.MouseEventArgs e)
+        private void LakiToolGLControl1_MouseDown(object sender, System.Windows.Forms.MouseEventArgs e)
         {
             mic = true;
         }
 
-        private void remouseup(object sender, System.Windows.Forms.MouseEventArgs e)
+        private void LakiToolGLControl1_MouseUp(object sender, System.Windows.Forms.MouseEventArgs e)
         {
             mic = false;
         }
@@ -247,6 +176,9 @@ namespace LakiTool
         #endregion
 
         #region Render Loop
+
+        Render.Renderer renderer = new Render.Renderer();
+        Camera cam = new Camera();
 
         bool isRenderLoopEnabled;
 
@@ -264,18 +196,95 @@ namespace LakiTool
             if (!isRenderLoopEnabled) return;
             isRenderLoopEnabled = false;
 
+            renderer.Dispose();
+
             StopTimer();
             Application.Idle -= Application_Idle;
         }
 
-        void Application_Idle(object sender, EventArgs e)
+        private void Application_Idle(object sender, EventArgs e)
         {
             if (!ContainsFocus) return;
 
-            while (glcontrol1.IsIdle)
+            while (lakiToolGLControl1.IsIdle)
             {
-                doRenderStuff(deltaTime);
+                Update(deltaTime);
             }
+        }
+
+        private void Update(float deltaTime)
+        {
+            checkkeys(deltaTime);
+            checkmouse();
+
+            Render(lakiToolGLControl1);
+
+            ProcessTimer();
+        }
+
+        private void Render(GLControl RenderPanel)
+        {
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+
+            Matrix4 modelview = cam.GetViewMatrix();
+            GL.MatrixMode(MatrixMode.Modelview);
+            GL.LoadMatrix(ref modelview);
+
+            Vector3 lookat = new Vector3();
+            lookat.X = (float)(Math.Cos((float)cam.Orientation.X) * Math.Cos((float)cam.Orientation.Y));
+            lookat.Y = (float)Math.Sin((float)cam.Orientation.Y);
+            lookat.Z = (float)(Math.Sin((float)cam.Orientation.X) * Math.Cos((float)cam.Orientation.Y));
+            GL.Light(LightName.Light0, LightParameter.Position, new float[] { Math.Abs(lookat.X), Math.Abs(lookat.Y), Math.Abs(lookat.Z), 0.0f });
+
+            renderer.Render();
+
+            RenderPanel.SwapBuffers();
+        }
+
+        private void InitialiseView()
+        {
+            GL.ClearColor(Color.LightBlue);
+
+            GL.Enable(EnableCap.CullFace);
+            GL.CullFace(CullFaceMode.Back);
+
+            GL.Enable(EnableCap.Blend);
+            GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+
+            GL.Enable(EnableCap.DepthTest);
+            GL.DepthFunc(DepthFunction.Lequal);
+
+            GL.Enable(EnableCap.AlphaTest);
+            GL.AlphaFunc(AlphaFunction.Gequal, 0.05f);
+
+            GL.Enable(EnableCap.ColorMaterial);
+            GL.Enable(EnableCap.Normalize);
+            GL.Enable(EnableCap.Texture2D);
+
+            GL.ShadeModel(ShadingModel.Smooth);
+            GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Fill);
+
+            GL.Enable(EnableCap.Lighting);
+            GL.Enable(EnableCap.Light0);
+
+#if DEBUG
+            InitializeDebugMessages();
+#endif
+        }
+
+        private void UpdateProjectionMatrix()
+        {
+            Rectangle renderRect = lakiToolGLControl1.ClientRectangle;
+            GL.Viewport(renderRect.X, renderRect.Y, renderRect.Width, renderRect.Height);
+            Matrix4 projection = Matrix4.CreatePerspectiveFieldOfView(1.0f, renderRect.Width / (float)renderRect.Height, 1f, 1000.0f);
+            GL.MatrixMode(MatrixMode.Projection);
+            GL.LoadMatrix(ref projection);
+        }
+
+        private void ResetCamera()
+        {
+            cam.Position = Vector3.Zero;
+            cam.Orientation = Vector3.UnitZ;
         }
 
         #endregion
@@ -325,6 +334,47 @@ namespace LakiTool
                 lastFPSUpdate = totalElapsedTime;
             }
         }
+
+        #endregion
+
+        #region Debug
+
+#if DEBUG
+
+        DebugProc DebugProcCallback;
+
+        void InitializeDebugMessages()
+        {
+            GL.Enable(EnableCap.DebugOutput);
+            DebugProcCallback = DebugMessage;
+            GL.DebugMessageCallback(DebugProcCallback, IntPtr.Zero);
+        }
+
+        void DebugMessage(DebugSource source, DebugType type, int id, DebugSeverity severity, int length, IntPtr message, IntPtr userParam)
+        {
+            var msg = System.Runtime.InteropServices.Marshal.PtrToStringAnsi(message, length);
+            Console.WriteLine(string.Format("{0} {1} {2}", severity, type, msg));
+        }
+
+        //static System.Runtime.InteropServices.GCHandle _logCallbackHandle;
+        //static readonly DebugProcArb debugDelegate = new DebugProcArb(DebugMessage);
+
+        //void InitializeDebugMessages()
+        //{
+        //    GL.Enable(EnableCap.DebugOutput);
+        //    GL.Enable(EnableCap.DebugOutputSynchronous);
+        //    _logCallbackHandle = System.Runtime.InteropServices.GCHandle.Alloc(debugDelegate);
+        //    var nullptr = new IntPtr(0);
+        //    GL.Arb.DebugMessageCallback(debugDelegate, nullptr);
+        //}
+
+        //static void DebugMessage(DebugSource source, DebugType type, int id, DebugSeverity severity, int length, IntPtr message, IntPtr userParam)
+        //{
+        //    var msg = System.Runtime.InteropServices.Marshal.PtrToStringAnsi(message, length);
+        //    Console.WriteLine(string.Format("{0} {1} {2}", severity, type, msg));
+        //}
+
+#endif
 
         #endregion
     }

--- a/Forms/LakiToolGLControl.cs
+++ b/Forms/LakiToolGLControl.cs
@@ -1,0 +1,23 @@
+﻿using OpenTK;
+using OpenTK.Graphics;
+
+namespace LakiTool.Forms
+{
+    class LakiToolGLControl : GLControl
+    {
+#if DEBUG
+
+        public LakiToolGLControl() : base(GraphicsMode.Default, 1, 0, GraphicsContextFlags.Debug)
+        {
+
+        }
+#else
+
+        public LakiToolGLControl() : base(GraphicsMode.Default, 1, 0, GraphicsContextFlags.Default)
+        {
+
+        }
+
+#endif
+    }
+}

--- a/GBI/GBI.cs
+++ b/GBI/GBI.cs
@@ -73,7 +73,7 @@ namespace LakiTool.GBI
             GL.End();
             GL.Light(LightName.Light0, LightParameter.Diffuse, new float[] { (float)r / 255f, (float)g / 255f, (float)g / 255f, (float)a / 255f });
             GL.ColorMaterial(MaterialFace.Front, ColorMaterialParameter.Diffuse);
-            GL.Begin(BeginMode.Triangles);
+            GL.Begin(PrimitiveType.Triangles);
         }
 
         public void gsSPLight(float[] lightcolor, byte type)
@@ -81,7 +81,7 @@ namespace LakiTool.GBI
             GL.End();
             GL.Light(LightName.Light0, (type == 1) ? LightParameter.Diffuse : LightParameter.Ambient, lightcolor);
             GL.ColorMaterial(MaterialFace.Front, (type == 1) ? ColorMaterialParameter.Diffuse : ColorMaterialParameter.Ambient);
-            GL.Begin(BeginMode.Triangles);
+            GL.Begin(PrimitiveType.Triangles);
         }
 
         public void gsSPVertex(Vtx[] verteces, byte length, byte start)

--- a/GBI/Utils/F3DUtils.cs
+++ b/GBI/Utils/F3DUtils.cs
@@ -41,7 +41,7 @@ namespace LakiTool
                     GL.Disable(EnableCap.Lighting);
                 }
             }
-            GL.Begin(BeginMode.Triangles);
+            GL.Begin(PrimitiveType.Triangles);
         }
 
         public static void setUpVertColor(byte r, byte g, byte b, byte a, uint geommode)

--- a/Geo/GeoObject.cs
+++ b/Geo/GeoObject.cs
@@ -15,7 +15,7 @@ namespace LakiTool.Geo
         RenderObject
     }
 
-    class GeoObject
+    class GeoObject: IDisposable
     {
         public Geo.Rotation objRot = new Geo.Rotation();
         public Geo.Translation objTrans = new Geo.Translation();
@@ -58,6 +58,11 @@ namespace LakiTool.Geo
         private void SetScaling(Geo.Scaling scaleObj)
         {
             GL.Scale(scaleObj.GetVector());
+        }
+
+        public void Dispose()
+        {
+            if (f3d != null) f3d.Dispose();
         }
     }
 }

--- a/LakiTool.csproj
+++ b/LakiTool.csproj
@@ -62,6 +62,9 @@
     <Compile Include="C\CConsts.cs" />
     <Compile Include="C\Utils\CUtils.cs" />
     <Compile Include="C\Utils\GCUtil.cs" />
+    <Compile Include="Forms\LakiToolGLControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="GBI\DL.cs" />
     <Compile Include="GBI\F3DCommand.cs" />
     <Compile Include="GBI\F3DParam.cs" />

--- a/OBJs/Special/SpecialObjectRenderStack.cs
+++ b/OBJs/Special/SpecialObjectRenderStack.cs
@@ -70,7 +70,7 @@ namespace LakiTool.OBJs.Special
             f = true;
 
             OBJs.Util.ObjUtil.setUpCubeDataRendering(0.8f, 0.2f, 0.2f);
-            GL.Begin(BeginMode.Lines);
+            GL.Begin(PrimitiveType.Lines);
             for (int i = 0; i<cubeData.Count; i++)
             {
                 cubeData[i].Render();

--- a/Render/F3DRenderer.cs
+++ b/Render/F3DRenderer.cs
@@ -50,6 +50,8 @@ namespace LakiTool.Render
             parser = new ParseF3D(F3DUtils.getF3DCommandsFromLines(lines), lutmanager.jumpContainer);
             labelsearchers = F3DUtils.getLabelSearchersFromLabelContainer(new Labels.LabelContainer(Labels.Utils.LabelUtil.getLabelListFromModelFile(fileName)), lines);
 
+            GL.Enable(EnableCap.Texture2D);
+
             displayListGenerated = false;
         }
 

--- a/Render/GeoRenderer.cs
+++ b/Render/GeoRenderer.cs
@@ -7,7 +7,7 @@ using OpenTK.Graphics.OpenGL;
 
 namespace LakiTool.Render
 {
-    class GeoRenderer
+    class GeoRenderer: IDisposable
     {
         private bool inited = false;
 
@@ -50,6 +50,14 @@ namespace LakiTool.Render
                         //GL.PopMatrix();
                         break;
                 }
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (Geo.GeoObject geoObject in geoObjects)
+            {
+                if (geoObject != null) geoObject.Dispose();
             }
         }
     }

--- a/Render/LvlRenderer.cs
+++ b/Render/LvlRenderer.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace LakiTool.Render
 {
-    class LvlRenderer
+    class LvlRenderer: IDisposable
     {
         private bool inited = false;
         //private Lvl.LevelScript levelScript = new Lvl.LevelScript();
@@ -24,6 +24,11 @@ namespace LakiTool.Render
         {
             if (!inited) return;
             //still need to add shit here
+        }
+
+        public void Dispose()
+        {
+
         }
     }
 }

--- a/Render/Renderer.cs
+++ b/Render/Renderer.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using OpenTK.Graphics.OpenGL;
+﻿using OpenTK.Graphics.OpenGL;
+using System;
 
 namespace LakiTool.Render
 {
@@ -15,7 +11,7 @@ namespace LakiTool.Render
         Level
     }
 
-    class Renderer
+    class Renderer : IDisposable
     {
         private RenderMode mode;
         public RendererObject rendererObject = new RendererObject();
@@ -27,12 +23,14 @@ namespace LakiTool.Render
             switch (mode)
             {
                 case RenderMode.F3D:
+                    if (rendererObject.F3Drenderer != null) rendererObject.F3Drenderer.Dispose();
                     rendererObject.F3Drenderer = new F3DRenderer();
                     break;
                 case RenderMode.Collision:
                     rendererObject.Colrenderer = new ColRenderer();
                     break;
                 case RenderMode.Geo:
+                    if (rendererObject.Georenderer != null) rendererObject.Georenderer.Dispose();
                     rendererObject.Georenderer = new GeoRenderer();
                     break;
                 case RenderMode.Level:
@@ -51,6 +49,12 @@ namespace LakiTool.Render
             GL.Color3(1.0f, 1.0f, 1.0f); //reset color to white
             F3DUtils.setUpWrapST(0, 0); //reset wrap data
             rendererObject.Render();
+        }
+
+        public void Dispose()
+        {
+            if (rendererObject.F3Drenderer != null) rendererObject.F3Drenderer.Dispose();
+            if (rendererObject.Georenderer != null) rendererObject.Georenderer.Dispose();
         }
     }
 }

--- a/Render/Renderer.cs
+++ b/Render/Renderer.cs
@@ -23,18 +23,16 @@ namespace LakiTool.Render
             switch (mode)
             {
                 case RenderMode.F3D:
-                    if (rendererObject.F3Drenderer != null) rendererObject.F3Drenderer.Dispose();
-                    rendererObject.F3Drenderer = new F3DRenderer();
+                    rendererObject.CreateF3DRenderer();
                     break;
                 case RenderMode.Collision:
-                    rendererObject.Colrenderer = new ColRenderer();
+                    rendererObject.CreateColRenderer();
                     break;
                 case RenderMode.Geo:
-                    if (rendererObject.Georenderer != null) rendererObject.Georenderer.Dispose();
-                    rendererObject.Georenderer = new GeoRenderer();
+                    rendererObject.CreateGeoRenderer();
                     break;
                 case RenderMode.Level:
-                    rendererObject.Lvlrenderer = new LvlRenderer();
+                    rendererObject.CreateLvlRenderer();
                     break;
             }
         }
@@ -53,8 +51,7 @@ namespace LakiTool.Render
 
         public void Dispose()
         {
-            if (rendererObject.F3Drenderer != null) rendererObject.F3Drenderer.Dispose();
-            if (rendererObject.Georenderer != null) rendererObject.Georenderer.Dispose();
+            rendererObject.Dispose();
         }
     }
 }

--- a/Render/RendererObject.cs
+++ b/Render/RendererObject.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LakiTool.Render
 {
-    class RendererObject
+    class RendererObject : IDisposable
     {
         private RenderMode mode;
 
@@ -50,9 +46,54 @@ namespace LakiTool.Render
             }
         }
 
-        public F3DRenderer F3Drenderer;
-        public ColRenderer Colrenderer;
-        public GeoRenderer Georenderer;
-        public LvlRenderer Lvlrenderer;
+        public void Dispose()
+        {
+            if (F3Drenderer != null) F3Drenderer.Dispose();
+            if (Colrenderer != null) Colrenderer.Dispose();
+            if (Georenderer != null) Georenderer.Dispose();
+            if (Lvlrenderer != null) Lvlrenderer.Dispose();
+            CleanRenderers();
+        }
+
+        public F3DRenderer F3Drenderer { get; private set; }
+        public ColRenderer Colrenderer { get; private set; }
+        public GeoRenderer Georenderer { get; private set; }
+        public LvlRenderer Lvlrenderer { get; private set; }
+
+        public void CreateF3DRenderer()
+        {
+            if (F3Drenderer != null) F3Drenderer.Dispose();
+            CleanRenderers();
+            F3Drenderer = new F3DRenderer();
+        }
+
+        public void CreateColRenderer()
+        {
+            if (Colrenderer != null) Colrenderer.Dispose();
+            CleanRenderers();
+            Colrenderer = new ColRenderer();
+        }
+
+        public void CreateGeoRenderer()
+        {
+            if (Georenderer != null) Georenderer.Dispose();
+            CleanRenderers();
+            Georenderer = new GeoRenderer();
+        }
+
+        public void CreateLvlRenderer()
+        {
+            if (Lvlrenderer != null) Lvlrenderer.Dispose();
+            CleanRenderers();
+            Lvlrenderer = new LvlRenderer();
+        }
+
+        void CleanRenderers()
+        {
+            Lvlrenderer = null;
+            Colrenderer = null;
+            Georenderer = null;
+            Lvlrenderer = null;
+        }
     }
 }


### PR DESCRIPTION
A bunch of stuff, each commit has more detailed information. But the biggest one is to use display lists to batch GL commands when rendering f3d, geo and collisions. That avoids sending many commands to the GPU and parsing the dl / collision data every frame.

I got 5x speed increase while rendering a complex level like HMC's geo, and 37x increase while rendering its collision.